### PR TITLE
feat: 몰로코, 두나무 ,센드버드 Scraper 추가

### DIFF
--- a/src/main/java/com/aztgg/scheduler/global/asset/PredefinedCompany.java
+++ b/src/main/java/com/aztgg/scheduler/global/asset/PredefinedCompany.java
@@ -20,6 +20,9 @@ public enum PredefinedCompany {
     TOSS("토스"),
     NEXON("넥슨"),
     KRAFTON("크래프톤"),
+    MOLOCO("몰로코"),
+    DUNAMU("두나무"),
+    SENDBIRD("센드버드"),
     ;
 
     private final String korean;

--- a/src/main/java/com/aztgg/scheduler/global/asset/PredefinedCorporate.java
+++ b/src/main/java/com/aztgg/scheduler/global/asset/PredefinedCorporate.java
@@ -103,6 +103,15 @@ public enum PredefinedCorporate {
     KRAFTON_FLYWAY("FlywayGames", PredefinedCompany.KRAFTON, "Flyway Games"),
     KRAFTON_OVERDARE("OVERDARE", PredefinedCompany.KRAFTON, "OVERDARE"),
     KRAFTON_TANGO("TangoGameworks", PredefinedCompany.KRAFTON, "탱고게임웍스"),
+
+    // 두나무
+    DUNAMU("DUNAMU", PredefinedCompany.DUNAMU, "두나무"),
+
+    // 몰로코
+    MOLOCO("MOLOCO", PredefinedCompany.MOLOCO, "몰로코"),
+
+    // 센드버드
+    SENDBIRD("SENDBIRD", PredefinedCompany.SENDBIRD, "센드버드"),
     ;
 
     private final String id; // 각 스크랩 시 공고의 대상 법인을 식별하는 값

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/CoupangNoticeCollectorService.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/CoupangNoticeCollectorService.java
@@ -15,9 +15,9 @@ import java.util.List;
 
 @Slf4j
 @Service
-public class CoupangNoticeControllerService extends RecruitmentNoticeCollectorService {
+public class CoupangNoticeCollectorService extends RecruitmentNoticeCollectorService {
 
-    public CoupangNoticeControllerService(RecruitmentNoticeRepository recruitmentNoticeRepository,
+    public CoupangNoticeCollectorService(RecruitmentNoticeRepository recruitmentNoticeRepository,
                                           ApplicationEventPublisher applicationEventPublisher) {
         super(recruitmentNoticeRepository, ScrapGroupCodeType.COUPANG);
     }

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/DunamuNoticeCollectorService.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/DunamuNoticeCollectorService.java
@@ -1,0 +1,33 @@
+package com.aztgg.scheduler.recruitmentnotice.application.collectorservice;
+
+import com.aztgg.scheduler.recruitmentnotice.application.RecruitmentNoticeCollectorService;
+import com.aztgg.scheduler.recruitmentnotice.domain.ScrapGroupCodeType;
+import com.aztgg.scheduler.recruitmentnotice.domain.RecruitmentNoticeRepository;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.Scraper;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dto.RecruitmentNoticeDto;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dunamu.DunamuNoticesScraper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class DunamuNoticeCollectorService extends RecruitmentNoticeCollectorService {
+
+    public DunamuNoticeCollectorService(RecruitmentNoticeRepository recruitmentNoticeRepository) {
+        super(recruitmentNoticeRepository, ScrapGroupCodeType.DUNAMU);
+    }
+    
+    @Override
+    protected List<RecruitmentNoticeDto> result() {
+        try {
+            Scraper<List<RecruitmentNoticeDto>> scraper = new DunamuNoticesScraper();
+            return scraper.scrap();
+        } catch (Exception e) {
+            log.error("Error occurred while scraping Dunamu job postings", e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/MolocoNoticeCollectorService.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/MolocoNoticeCollectorService.java
@@ -1,0 +1,39 @@
+package com.aztgg.scheduler.recruitmentnotice.application.collectorservice;
+
+import com.aztgg.scheduler.recruitmentnotice.application.RecruitmentNoticeCollectorService;
+import com.aztgg.scheduler.recruitmentnotice.domain.ScrapGroupCodeType;
+import com.aztgg.scheduler.recruitmentnotice.domain.RecruitmentNoticeRepository;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.Scraper;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dto.RecruitmentNoticeDto;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.moloco.MolocoNoticesScraper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class MolocoNoticeCollectorService extends RecruitmentNoticeCollectorService {
+
+    private final RestClient molocoCareersPublicRestClient;
+
+    public MolocoNoticeCollectorService(RecruitmentNoticeRepository recruitmentNoticeRepository,
+                                         RestClient molocoCareersPublicRestClient) {
+        super(recruitmentNoticeRepository, ScrapGroupCodeType.MOLOCO);
+        this.molocoCareersPublicRestClient = molocoCareersPublicRestClient;
+    }
+
+    @Override
+    protected List<RecruitmentNoticeDto> result() {
+        Scraper<List<RecruitmentNoticeDto>> scraper = new MolocoNoticesScraper(molocoCareersPublicRestClient);
+        List<RecruitmentNoticeDto> scrapResult = new ArrayList<>();
+        try {
+            scrapResult.addAll(scraper.scrap());
+        } catch (Exception e) {
+            log.error("unexpected exception", e);
+        }
+        return scrapResult;
+    }
+}

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/NaverNoticeCollectorService.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/NaverNoticeCollectorService.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 @Slf4j
 @Service
-public class NaverNoticeControllerService extends RecruitmentNoticeCollectorService {
+public class NaverNoticeCollectorService extends RecruitmentNoticeCollectorService {
     private final RestClient naverCareersPublicRestClient;
 
-    public NaverNoticeControllerService(RecruitmentNoticeRepository recruitmentNoticeRepository,
+    public NaverNoticeCollectorService(RecruitmentNoticeRepository recruitmentNoticeRepository,
                                         RestClient naverCareersPublicRestClient) {
         super(recruitmentNoticeRepository, ScrapGroupCodeType.NAVER);
         this.naverCareersPublicRestClient = naverCareersPublicRestClient;

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/SendbirdNoticeCollectorService.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/application/collectorservice/SendbirdNoticeCollectorService.java
@@ -1,0 +1,38 @@
+package com.aztgg.scheduler.recruitmentnotice.application.collectorservice;
+
+import com.aztgg.scheduler.recruitmentnotice.application.RecruitmentNoticeCollectorService;
+import com.aztgg.scheduler.recruitmentnotice.domain.RecruitmentNoticeRepository;
+import com.aztgg.scheduler.recruitmentnotice.domain.ScrapGroupCodeType;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.Scraper;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dto.RecruitmentNoticeDto;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.sendbird.SendbirdNoticesScraper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class SendbirdNoticeCollectorService extends RecruitmentNoticeCollectorService {
+
+    private final RestClient sendbirdCareersPublicRestClient;
+
+    public SendbirdNoticeCollectorService(RecruitmentNoticeRepository recruitmentNoticeRepository,
+                                         RestClient sendbirdCareersPublicRestClient) {
+        super(recruitmentNoticeRepository, ScrapGroupCodeType.SENDBIRD);
+        this.sendbirdCareersPublicRestClient = sendbirdCareersPublicRestClient;
+    }
+
+    @Override
+    protected List<RecruitmentNoticeDto> result() {
+        try {
+            Scraper<List<RecruitmentNoticeDto>> scraper = new SendbirdNoticesScraper(sendbirdCareersPublicRestClient);
+            return scraper.scrap();
+        } catch (Exception e) {
+            log.error("Error occurred while scraping Sendbird job postings", e);
+            return new ArrayList<>();
+        }
+    }
+} 

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/ScrapGroupCodeType.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/ScrapGroupCodeType.java
@@ -22,6 +22,9 @@ public enum ScrapGroupCodeType {
     COUPANG(PredefinedCompany.COUPANG),
     NEXON(PredefinedCompany.NEXON),
     KRAFTON(PredefinedCompany.KRAFTON),
+    MOLOCO(PredefinedCompany.MOLOCO),
+    DUNAMU(PredefinedCompany.DUNAMU),
+    SENDBIRD(PredefinedCompany.SENDBIRD),
     ;
 
     private final PredefinedCompany company;

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/scraper/dunamu/DunamuNoticesScraper.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/scraper/dunamu/DunamuNoticesScraper.java
@@ -1,0 +1,122 @@
+package com.aztgg.scheduler.recruitmentnotice.domain.scraper.dunamu;
+
+import com.aztgg.scheduler.global.asset.PredefinedCorporate;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.Scraper;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dto.RecruitmentNoticeDto;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class DunamuNoticesScraper implements Scraper<List<RecruitmentNoticeDto>> {
+
+    private static final String DUNAMU_CAREERS_URL = "https://dunamu.com/careers/jobs";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public List<RecruitmentNoticeDto> scrap() throws IOException {
+        try {
+            log.info("Starting to scrape Dunamu job postings from HTML: {}", DUNAMU_CAREERS_URL);
+            
+            Document document = Jsoup.connect(DUNAMU_CAREERS_URL)
+                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+                    .timeout(10000)
+                    .get();
+            
+            // __NEXT_DATA__ 스크립트에서 JSON 데이터 추출
+            Element nextDataScript = document.selectFirst("script#__NEXT_DATA__");
+            if (nextDataScript == null) {
+                log.warn("Could not find __NEXT_DATA__ script in Dunamu careers page");
+                return Collections.emptyList();
+            }
+            
+            String jsonData = nextDataScript.html();
+            DunamuNextDataDto nextData = objectMapper.readValue(jsonData, DunamuNextDataDto.class);
+            
+            if (nextData.props() == null || nextData.props().pageProps() == null || 
+                nextData.props().pageProps().articles() == null || 
+                nextData.props().pageProps().articles().content() == null) {
+                log.warn("No job postings found in Dunamu __NEXT_DATA__");
+                return Collections.emptyList();
+            }
+            
+            List<RecruitmentNoticeDto> notices = nextData.props().pageProps().articles().content().stream()
+                    .filter(article -> "ARTICLE".equals(article.categoryKind())) // 공지사항 제외, 실제 채용공고만
+                    .map(this::convertToRecruitmentNotice)
+                    .collect(Collectors.toList());
+            
+            log.info("Successfully scraped {} Dunamu job notices from HTML", notices.size());
+            return notices;
+            
+        } catch (Exception e) {
+            log.error("Failed to scrape Dunamu job postings from HTML. Error: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    private RecruitmentNoticeDto convertToRecruitmentNotice(DunamuArticleDto article) {
+        Set<String> categories = new HashSet<>();
+        if (article.categoryDisplayName() != null && !article.categoryDisplayName().isEmpty()) {
+            categories.add(article.categoryDisplayName());
+        }
+        
+        String jobUrl = "https://dunamu.com/careers/jobs/" + article.id();
+        
+        LocalDateTime startAt = parseDateTime(article.createdAt());
+        LocalDateTime endAt = parseDateTime(article.updatedAt());
+        
+        return RecruitmentNoticeDto.builder()
+                .jobOfferTitle(article.title())
+                .url(jobUrl)
+                .categories(categories)
+                .corporateCodes(Set.of(PredefinedCorporate.DUNAMU.name()))
+                .startAt(startAt)
+                .endAt(endAt)
+                .build();
+    }
+    
+    private LocalDateTime parseDateTime(String dateTimeString) {
+        if (dateTimeString == null || dateTimeString.isEmpty()) {
+            return null;
+        }
+        try {
+            // ISO 8601 형식 ("2025-06-02T19:29:09") 파싱
+            return LocalDateTime.parse(dateTimeString, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        } catch (Exception e) {
+            log.warn("Failed to parse datetime: {}, error: {}", dateTimeString, e.getMessage());
+            return null;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record DunamuNextDataDto(PropsDto props) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record PropsDto(PagePropsDto pageProps) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record PagePropsDto(ArticlesDto articles) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ArticlesDto(List<DunamuArticleDto> content) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record DunamuArticleDto(
+            Long id,
+            String title,
+            String summary,
+            String categoryDisplayName,
+            String categoryKind,
+            String createdAt,
+            String updatedAt
+    ) {}
+}

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/scraper/moloco/MolocoNoticesScraper.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/scraper/moloco/MolocoNoticesScraper.java
@@ -1,0 +1,170 @@
+package com.aztgg.scheduler.recruitmentnotice.domain.scraper.moloco;
+
+import com.aztgg.scheduler.global.asset.PredefinedCorporate;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.Scraper;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dto.RecruitmentNoticeDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class MolocoNoticesScraper implements Scraper<List<RecruitmentNoticeDto>> {
+
+    private static final String MOLOCO_CAREERS_URL = "https://www.moloco.com/ko/open-positions";
+    private final RestClient molocoCareersPublicRestClient;
+
+    public MolocoNoticesScraper(RestClient molocoCareersPublicRestClient) {
+        this.molocoCareersPublicRestClient = molocoCareersPublicRestClient;
+    }
+
+    /**
+     * 몰로코 공고 스크랩
+     * @return 몰로코 공고 스크랩 목록
+     * */
+    @Override
+    public List<RecruitmentNoticeDto> scrap() throws IOException {
+        try {
+            log.info("Starting to scrape Moloco job postings");
+            
+            // 먼저 카테고리 정보를 크롤링
+            Map<String, String> jobCategories = scrapeJobCategories();
+            log.info("Scraped categories: {}", jobCategories);
+            
+            // API에서 job 정보를 가져옴
+            MolocoJobsApiResponseDto response = molocoCareersPublicRestClient.get()
+                    .uri("/jobs?content=false")
+                    .retrieve()
+                    .body(MolocoJobsApiResponseDto.class);
+
+            if (response == null || response.jobs() == null) {
+                log.warn("No job data received from Moloco API");
+                return new ArrayList<>();
+            }
+
+            List<RecruitmentNoticeDto> jobs = response.jobs().stream()
+                    .map(job -> convertToRecruitmentNotice(job, jobCategories))
+                    .collect(Collectors.toList());
+
+            log.info("Successfully scraped {} jobs from Moloco", jobs.size());
+            return jobs;
+
+        } catch (Exception e) {
+            log.error("Failed to fetch jobs from Moloco API. Error: {}", e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    private Map<String, String> scrapeJobCategories() {
+        WebDriver driver = null;
+        try {
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments("--headless");
+            options.addArguments("--no-sandbox");
+            options.addArguments("--disable-dev-shm-usage");
+            options.addArguments("--window-size=1920,1080");
+            options.addArguments("--disable-gpu");
+            options.addArguments("--remote-allow-origins=*");
+            
+            driver = new ChromeDriver(options);
+            driver.get(MOLOCO_CAREERS_URL);
+            
+            // 페이지가 로드될 때까지 대기
+            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+            wait.until(d -> d.findElement(By.cssSelector("div[class*='job-departments-section']")));
+            
+            // 잠시 대기하여 동적 콘텐츠가 모두 로드되도록 함
+            Thread.sleep(2000);
+            
+            Map<String, String> categories = new HashMap<>();
+            
+            // 각 부서 섹션의 카테고리 정보 추출
+            List<WebElement> sections = driver.findElements(By.cssSelector("div[class*='job-departments-section']"));
+            for (WebElement section : sections) {
+                try {
+                    WebElement categoryElement = section.findElement(By.cssSelector("h4"));
+                    if (categoryElement != null) {
+                        String category = categoryElement.getText().trim();
+                        if (!category.isEmpty()) {
+                            // 해당 섹션의 모든 job 링크를 찾아서 카테고리와 매핑
+                            List<WebElement> jobLinks = section.findElements(By.cssSelector("a[href*='/jobs/']"));
+                            for (WebElement jobLink : jobLinks) {
+                                String jobUrl = jobLink.getAttribute("href");
+                                if (jobUrl != null && !jobUrl.isEmpty()) {
+                                    categories.put(jobUrl, category);
+                                    log.debug("Mapped job URL {} to category {}", jobUrl, category);
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to extract category from section: {}", e.getMessage());
+                }
+            }
+            
+            log.info("Successfully scraped {} job categories from Moloco website", categories.size());
+            return categories;
+            
+        } catch (Exception e) {
+            log.warn("Failed to scrape job categories from Moloco website: {}", e.getMessage());
+            return Collections.emptyMap();
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+    private RecruitmentNoticeDto convertToRecruitmentNotice(MolocoJobDto job, Map<String, String> jobCategories) {
+        LocalDateTime startAt = job.firstPublished() != null ? 
+            job.firstPublished().atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+        LocalDateTime endAt = job.updatedAt() != null ? 
+            job.updatedAt().atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+            
+        Set<String> categories = new HashSet<>();
+        
+        // job URL을 키로 사용하여 카테고리 매핑
+        String category = jobCategories.get(job.absoluteUrl());
+        if (category != null && !category.isEmpty()) {
+            categories.add(category);
+        }
+            
+        return RecruitmentNoticeDto.builder()
+                .jobOfferTitle(job.title())
+                .url(job.absoluteUrl())
+                .categories(categories)
+                .corporateCodes(Set.of(PredefinedCorporate.MOLOCO.name()))
+                .startAt(startAt)
+                .endAt(endAt)
+                .build();
+    }
+
+    private record MolocoJobsApiResponseDto(List<MolocoJobDto> jobs, MetaDto meta) {}
+
+    private record MetaDto(Integer total) {}
+
+    private record MolocoJobDto(
+            Long id,
+            String title,
+            @JsonProperty("absolute_url") String absoluteUrl,
+            @JsonProperty("company_name") String companyName,
+            LocationDto location,
+            @JsonProperty("first_published") OffsetDateTime firstPublished,
+            @JsonProperty("updated_at") OffsetDateTime updatedAt
+    ) {}
+
+    private record LocationDto(String name) {}
+}

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/scraper/sendbird/SendbirdNoticesScraper.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/domain/scraper/sendbird/SendbirdNoticesScraper.java
@@ -1,0 +1,134 @@
+package com.aztgg.scheduler.recruitmentnotice.domain.scraper.sendbird;
+
+import com.aztgg.scheduler.global.asset.PredefinedCorporate;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.Scraper;
+import com.aztgg.scheduler.recruitmentnotice.domain.scraper.dto.RecruitmentNoticeDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SendbirdNoticesScraper implements Scraper<List<RecruitmentNoticeDto>> {
+
+    private static final String SENDBIRD_CAREERS_URL = "https://sendbird.com/ko/careers";
+    private final RestClient sendbirdCareersPublicRestClient;
+
+    public SendbirdNoticesScraper(RestClient sendbirdCareersPublicRestClient) {
+        this.sendbirdCareersPublicRestClient = sendbirdCareersPublicRestClient;
+    }
+
+    @Override
+    public List<RecruitmentNoticeDto> scrap() throws IOException {
+        try {
+            log.info("Starting to scrape Sendbird job postings from Greenhouse API");
+            
+            SendbirdJobsApiResponseDto response = sendbirdCareersPublicRestClient.get()
+                    .uri("/jobs?content=false")
+                    .retrieve()
+                    .body(SendbirdJobsApiResponseDto.class);
+            
+            if (response == null || response.jobs() == null) {
+                log.warn("No job postings found in Sendbird Greenhouse API response");
+                return Collections.emptyList();
+            }
+            
+            // 웹사이트에서 카테고리 정보 크롤링
+            Map<String, String> jobCategories = scrapeJobCategories();
+            
+            List<RecruitmentNoticeDto> notices = response.jobs().stream()
+                    .map(job -> convertToRecruitmentNotice(job, jobCategories))
+                    .collect(Collectors.toList());
+            
+            log.info("Successfully scraped {} Sendbird job notices from Greenhouse API", notices.size());
+            return notices;
+            
+        } catch (Exception e) {
+            log.error("Failed to fetch jobs from Sendbird Greenhouse API. Error: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    private Map<String, String> scrapeJobCategories() {
+        try {
+            Document document = Jsoup.connect(SENDBIRD_CAREERS_URL)
+                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+                    .timeout(10000)
+                    .get();
+            
+            Map<String, String> categories = new HashMap<>();
+            
+            // 채용 공고 목록에서 각 공고의 카테고리 정보 추출
+            document.select("div.job-wrap").forEach(jobElement -> {
+                Element titleElement = jobElement.selectFirst("div.title");
+                Element departmentElement = jobElement.selectFirst("div.department");
+                
+                if (titleElement != null && departmentElement != null) {
+                    String title = titleElement.text().trim();
+                    String category = departmentElement.text().trim();
+                    if (!title.isEmpty() && !category.isEmpty()) {
+                        categories.put(title, category);
+                    }
+                }
+            });
+            
+            log.info("Successfully scraped {} job categories from Sendbird website", categories.size());
+            return categories;
+            
+        } catch (Exception e) {
+            log.warn("Failed to scrape job categories from Sendbird website: {}", e.getMessage());
+            return Collections.emptyMap();
+        }
+    }
+
+    private RecruitmentNoticeDto convertToRecruitmentNotice(SendbirdJobDto job, Map<String, String> jobCategories) {
+        LocalDateTime startAt = job.firstPublished() != null ? 
+            job.firstPublished().atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+        LocalDateTime endAt = job.updatedAt() != null ? 
+            job.updatedAt().atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime() : null;
+            
+        Set<String> categories = new HashSet<>();
+        
+        // 웹사이트에서 크롤링한 카테고리 정보 사용
+        String category = jobCategories.get(job.title());
+        if (category != null && !category.isEmpty()) {
+            categories.add(category);
+        }
+        
+        String jobUrl = "https://sendbird.com/ko/careers?gh_jid=" + job.id();
+            
+        return RecruitmentNoticeDto.builder()
+                .jobOfferTitle(job.title())
+                .url(jobUrl)
+                .categories(categories)
+                .corporateCodes(Set.of(PredefinedCorporate.SENDBIRD.name()))
+                .startAt(startAt)
+                .endAt(endAt)
+                .build();
+    }
+
+    private record SendbirdJobsApiResponseDto(List<SendbirdJobDto> jobs, MetaDto meta) {}
+
+    private record MetaDto(Integer total) {}
+
+    private record SendbirdJobDto(
+            Long id,
+            String title,
+            @JsonProperty("absolute_url") String absoluteUrl,
+            @JsonProperty("company_name") String companyName,
+            LocationDto location,
+            @JsonProperty("first_published") OffsetDateTime firstPublished,
+            @JsonProperty("updated_at") OffsetDateTime updatedAt
+    ) {}
+
+    private record LocationDto(String name) {}
+} 

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/infrastructure/config/CareersRestClientConfig.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/infrastructure/config/CareersRestClientConfig.java
@@ -79,4 +79,22 @@ public class CareersRestClientConfig {
                 .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
+
+    @Bean(name = "molocoCareersPublicRestClient")
+    public RestClient molocoCareersPublicRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://boards-api.greenhouse.io/v1/boards/moloco")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Bean(name = "sendbirdCareersPublicRestClient")
+    public RestClient sendbirdCareersPublicRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://boards-api.greenhouse.io/v1/boards/sendbird")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
 }

--- a/src/main/java/com/aztgg/scheduler/recruitmentnotice/presentation/RecruitmentNoticeScheduler.java
+++ b/src/main/java/com/aztgg/scheduler/recruitmentnotice/presentation/RecruitmentNoticeScheduler.java
@@ -19,11 +19,14 @@ public class RecruitmentNoticeScheduler {
     private final LineNoticeCollectorService lineNoticeCollectorService;
     private final DaangnNoticeCollectorService daangnNoticeCollectorService;
     private final KakaoBankNoticeCollectorService kakaoBankNoticeCollectorService;
-    private final NaverNoticeControllerService naverNoticeControllerService;
-    private final CoupangNoticeControllerService coupangNoticeControllerService;
+    private final NaverNoticeCollectorService naverNoticeCollectorService;
+    private final CoupangNoticeCollectorService coupangNoticeCollectorService;
     private final KakaoGreetingNoticeCollectorService kakaoGreetingNoticeCollectorService;
     private final NexonNoticesCollectorService nexonNoticesCollectorService;
     private final KraftonNoticesCollectorService kraftonNoticesCollectorService;
+    private final MolocoNoticeCollectorService molocoNoticeCollectorService;
+    private final DunamuNoticeCollectorService dunamuNoticeCollectorService;
+    private final SendbirdNoticeCollectorService sendbirdNoticeCollectorService;
 
     private final AiCategoryClassifierService aiCategoryClassifierService;
 
@@ -106,7 +109,7 @@ public class RecruitmentNoticeScheduler {
             log.debug("aztgg.donotnotice = true");
             return;
         }
-        naverNoticeControllerService.collect();
+        naverNoticeCollectorService.collect();
         aiCategoryClassifierService.classifyingNoticeCategories();
     }
 
@@ -116,7 +119,7 @@ public class RecruitmentNoticeScheduler {
             log.debug("aztgg.donotnotice = true");
             return;
         }
-        coupangNoticeControllerService.collect();
+        coupangNoticeCollectorService.collect();
         aiCategoryClassifierService.classifyingNoticeCategories();
     }
 
@@ -137,6 +140,36 @@ public class RecruitmentNoticeScheduler {
             return;
         }
         kraftonNoticesCollectorService.collect();
+        aiCategoryClassifierService.classifyingNoticeCategories();
+    }
+
+    @Scheduled(fixedDelay = 4_3200_000)
+    public void collectMolocoTotalNotices() {
+        if (doNotCollect) {
+            log.debug("aztgg.donotnotice = true");
+            return;
+        }
+        molocoNoticeCollectorService.collect();
+        aiCategoryClassifierService.classifyingNoticeCategories();
+    }
+
+    @Scheduled(fixedDelay = 4_3200_000)
+    public void collectDunamuTotalNotices() {
+        if (doNotCollect) {
+            log.debug("aztgg.donotnotice = true");
+            return;
+        }
+        dunamuNoticeCollectorService.collect();
+        aiCategoryClassifierService.classifyingNoticeCategories();
+    }
+
+    @Scheduled(fixedDelay = 4_3200_000)
+    public void collectSendbirdTotalNotices() {
+        if (doNotCollect) {
+            log.debug("aztgg.donotnotice = true");
+            return;
+        }
+        sendbirdNoticeCollectorService.collect();
         aiCategoryClassifierService.classifyingNoticeCategories();
     }
 }


### PR DESCRIPTION
## 이 PR이 포함하는 내용 / 필요한 이유

이 PR은 몰로코(Moloco), 두나무(Dunamu), 센드버드(Sendbird)에 대한 채용 공고 수집을 위한 Scraper를 새로 추가합니다.
기존에는 해당 기업들의 채용 정보를 수집할 수 없었으나, 본 PR을 통해 각 기업의 API 특성에 맞춘 수집기를 구현함으로써 수집 대상 기업의 범위를 확장하였습니다.

## 해결한 이슈
- close #34 

## 주요 구현 내용:
- 몰로코 (Moloco) - Greenhouse API 방식
- 두나무 (Dunamu) - Next.js Data API 방식
- 센드버드 (Sendbird) - Greenhouse API 방식

## 리뷰어에게
- 첫 PR이라 부족한 부분이 많을 것 같습니다. 코드 스타일, 아키텍처, 네이밍, 예외 처리 등 어떤 부분이든 개선할 점이 있으면 언제든지 피드백 부탁드립니다!